### PR TITLE
remove privtracker.com

### DIFF
--- a/torrent-websites
+++ b/torrent-websites
@@ -670,7 +670,6 @@ pornomen.club
 powertracker.org
 predb.me
 privatehd.to
-privtracker.com
 progressivetorrents.com
 prostylex.org
 proxahoy.link


### PR DESCRIPTION
While [Privtracker.com](https://privtracker.com/) is a website related to torrenting, it should not be considered a piracy website as it does not host any infringing content. The website simply provides a platform for users to share and download files through peer-to-peer technology.